### PR TITLE
Add onReady utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jasmine-reporters": "^2.2.0",
     "jasmine-spec-reporter": "^2.7.0",
     "jsdom": "^9.4.2",
+    "jsdom-global": "^2.1.1",
     "mocha": "^3.0.2",
     "mocha-jsdom": "^1.1.0",
     "require-dir": "^0.3.0",

--- a/src/utilities/on-ready/index.js
+++ b/src/utilities/on-ready/index.js
@@ -23,7 +23,7 @@ function onReady( fn ) {
   }
 
   // If the ready state is already complete, run the passed function,
-  // otherwise add it to our saved arrray
+  // otherwise add it to our saved array
   if ( document.readyState === 'complete' ) {
     fn();
   } else {
@@ -36,7 +36,7 @@ function onReady( fn ) {
       for ( var i = 0, l = _readyFunctions.length; i < l; i++ ) {
         _readyFunctions[i]();
       }
-      _readyFunctions = [];
+      _readyFunctions.length = 0;
     }
   };
 

--- a/src/utilities/on-ready/index.js
+++ b/src/utilities/on-ready/index.js
@@ -7,15 +7,14 @@
 
 'use strict';
 
-if ( !window.readyFunctions ) {
-  window.readyFunctions = [];
-}
+var _readyFunctions = [];
 
 /**
 * Checks if the document is ready, if it is, trigger the passed function,
 * if not, save the function to an array to be triggered after the page is loaded
 * @param {function} fn -
 *   Function to run only after the DOM has completely loaded
+* @returns {foo} bar
 */
 function onReady( fn ) {
   // Ensure we passed a function as the argument
@@ -28,18 +27,20 @@ function onReady( fn ) {
   if ( document.readyState === 'complete' ) {
     fn();
   } else {
-    window.readyFunctions.push( fn );
+    _readyFunctions.push( fn );
   }
 
   // When the ready state changes to complete, run the passed function
   document.onreadystatechange = function() {
     if ( document.readyState === 'complete' ) {
-      for ( var i = 0, l = window.readyFunctions.length; i < l; i++ ) {
-        window.readyFunctions[i]();
+      for ( var i = 0, l = _readyFunctions.length; i < l; i++ ) {
+        _readyFunctions[i]();
       }
-      window.readyFunctions = [];
+      _readyFunctions = [];
     }
   };
+
+  return _readyFunctions;
 }
 
 module.exports = {

--- a/src/utilities/on-ready/index.js
+++ b/src/utilities/on-ready/index.js
@@ -37,6 +37,7 @@ function onReady( fn ) {
       for ( var i = 0, l = window.readyFunctions.length; i < l; i++ ) {
         window.readyFunctions[i]();
       }
+      window.readyFunctions = [];
     }
   };
 }

--- a/src/utilities/on-ready/index.js
+++ b/src/utilities/on-ready/index.js
@@ -1,0 +1,46 @@
+/* ==========================================================================
+   On Ready
+
+   Utility for triggering functions only after the page is loaded
+
+   ========================================================================== */
+
+'use strict';
+
+if ( !window.readyFunctions ) {
+  window.readyFunctions = [];
+}
+
+/**
+* Checks if the document is ready, if it is, trigger the passed function,
+* if not, save the function to an array to be triggered after the page is loaded
+* @param {function} fn -
+*   Function to run only after the DOM has completely loaded
+*/
+function onReady( fn ) {
+  // Ensure we passed a function as the argument
+  if ( typeof fn !== 'function' ) {
+    return;
+  }
+
+  // If the ready state is already complete, run the passed function,
+  // otherwise add it to our saved arrray
+  if ( document.readyState === 'complete' ) {
+    fn();
+  } else {
+    window.readyFunctions.push( fn );
+  }
+
+  // When the ready state changes to complete, run the passed function
+  document.onreadystatechange = function() {
+    if ( document.readyState === 'complete' ) {
+      for ( var i = 0, l = window.readyFunctions.length; i < l; i++ ) {
+        window.readyFunctions[i]();
+      }
+    }
+  };
+}
+
+module.exports = {
+  onReady: onReady
+};

--- a/src/utilities/transition/ExpandableTransition.js
+++ b/src/utilities/transition/ExpandableTransition.js
@@ -5,8 +5,9 @@ var Events = require( '../../mixins/Events.js' );
 var BaseTransition = require( './BaseTransition' );
 var fnBind = require( '../function-bind' ).bind;
 var contains = require( '../dom-class-list' ).contains;
-var addClass = require( 'atomic-component/src/utilities/dom-class-list' ).addClass;
-var removeClass = require( 'atomic-component/src/utilities/dom-class-list' ).removeClass;
+var addClass = require( '../dom-class-list' ).addClass;
+var removeClass = require( '../dom-class-list' ).removeClass;
+var onReady = require( '../on-ready' ).onReady;
 
 // Exported constants.
 var CLASSES = {
@@ -26,7 +27,7 @@ var CLASSES = {
  *   DOM element to apply move transition to.
  * @param {classes} Object
  *   An Object of custom classes to override the base classes Object
- * @returns {ExpandableTransition} An instance. 
+ * @returns {ExpandableTransition} An instance.
  */
 function ExpandableTransition( element, classes ) { // eslint-disable-line max-statements, no-inline-comments, max-len
   var classObject = classes || CLASSES;
@@ -44,13 +45,15 @@ function ExpandableTransition( element, classes ) { // eslint-disable-line max-s
     _baseTransition.addEventListener( BaseTransition.END_EVENT,
                                       _transitionCompleteBinded );
 
-    if ( contains( element, classObject.OPEN_DEFAULT ) ) {
-      addClass( element, classObject.EXPANDED );
-      element.style.maxHeight = element.scrollHeight + 'px';
-    } else {
-      previousHeight = element.scrollHeight;
-      addClass( element, classObject.COLLAPSED );
-    }
+    onReady( function() {
+      if ( contains( element, classObject.OPEN_DEFAULT ) ) {
+        addClass( element, classObject.EXPANDED );
+        element.style.maxHeight = element.scrollHeight + 'px';
+      } else {
+        previousHeight = element.scrollHeight;
+        addClass( element, classObject.COLLAPSED );
+      }
+    } );
 
     return this;
   }

--- a/test/unit-test/components/atomic-component-spec.js
+++ b/test/unit-test/components/atomic-component-spec.js
@@ -31,7 +31,15 @@ describe( 'AtomicComponent', function() {
     function() {
       var element = document.getElementById( 'test-block-a');
       var initialize = sinon.spy();
-      var atomicComponent = new AtomicComponent( element, { initialize: initialize } );
+      var options = {
+        initialize: initialize,
+        events:     {
+          'keydown' : 'keyAction'
+        },
+        keyAction: sinon.stub()
+      };
+
+      var atomicComponent = new AtomicComponent( element, options );
       expect( atomicComponent.element === element ).to.equal( true );
       expect( atomicComponent.events ).to.be.an( 'object' );
       expect( initialize.called ).to.equal( true );

--- a/test/unit-test/components/atomic-component-spec.js
+++ b/test/unit-test/components/atomic-component-spec.js
@@ -34,7 +34,7 @@ describe( 'AtomicComponent', function() {
       var options = {
         initialize: initialize,
         events:     {
-          'keydown' : 'keyAction'
+          keydown: 'keyAction'
         },
         keyAction: sinon.stub()
       };

--- a/test/unit-test/utilities/on-ready-spec.js
+++ b/test/unit-test/utilities/on-ready-spec.js
@@ -101,9 +101,23 @@ describe( 'on-ready', function() {
       expect( _readyFunctions.length ).to.equal( 2 );
 
       return triggerReadyState( DOCUMENT_STATES.LOADING )
-              .then( function () {
-                 expect( typeof _readyFunctions ).to.equal( 'object' );
-                 expect( _readyFunctions.length ).to.equal( 2 );
+              .then( function() {
+                expect( typeof _readyFunctions ).to.equal( 'object' );
+                expect( _readyFunctions.length ).to.equal( 2 );
+              } );
+    }
+  );
+
+  it( 'should run the function if the page readyState has already completed',
+    function() {
+      var readyReturn;
+
+      return triggerReadyState( DOCUMENT_STATES.COMPLETE )
+              .then( function() {
+                onReady( function() {
+                  readyReturn = 'foo';
+                } );
+                expect( readyReturn ).to.equal( 'foo' );
               } );
     }
   );

--- a/test/unit-test/utilities/on-ready-spec.js
+++ b/test/unit-test/utilities/on-ready-spec.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var BASE_JS_PATH = '../../../src';
+
+var chai = require( 'chai' );
+var expect = chai.expect;
+var jsdom = require( 'jsdom-global' );
+var onReady;
+
+describe( 'on-ready', function() {
+  before( function() {
+    this.jsdom = jsdom();
+    onReady = require( BASE_JS_PATH + '/utilities/on-ready' ).onReady;
+  } );
+
+  after( function() {
+    this.jsdom();
+  } );
+
+  beforeEach( function() {
+    // You have to create your own readyState
+    // https://stackoverflow.com/questions/37059010/workarounds-for-jsdom-document-readystate-being-readonly/37061458
+    Object.defineProperty( document, 'readyState', {
+      get: function() { return 'loading'; },
+      configurable: true
+    } );
+  } );
+
+  // Complete our readyState if we didn't within the test
+  afterEach( function() {
+    if ( document.readyState !== 'complete' ) {
+      Object.defineProperty( document, 'readyState', {
+        get: function() { return 'complete'; }
+      } );
+    }
+  } );
+
+  it( 'should return early if passed a string',
+    function() {
+      onReady( 'foo' );
+
+      expect( typeof window.readyFuntions ).to.equal( 'undefined' );
+      expect( window.readyFunctions.length ).to.equal( 0 );
+    }
+  );
+
+  it( 'should add a funtion to the global array but not trigger it' +
+       'till readyState completes',
+    function() {
+      var readyReturn;
+
+      onReady( function() {
+        readyReturn = 'foo';
+      } );
+
+      expect( typeof window.readyFunctions ).to.equal( 'object' );
+      expect( window.readyFunctions.length ).to.equal( 1 );
+      expect( readyReturn ).to.equal( undefined );
+    }
+  );
+
+  // It seems that even though we're striggering the readyState,
+  // it's not triggering the change in our coude
+  xit( 'should trigger the function after readyState completes',
+    function() {
+      var readyReturn;
+
+      onReady( function() {
+        readyReturn = 'foo';
+      } );
+
+      Object.defineProperty( document, 'readyState', {
+        get: function() { return 'complete'; }
+      } );
+
+      expect( readyReturn ).to.equal( 'foo' );
+    }
+  );
+
+  // I believe it's the same issue here
+  xit( 'should clear the array after readyState completes',
+    function() {
+      onReady( function() {
+        return 'foo';
+      } );
+
+      Object.defineProperty( document, 'readyState', {
+        get: function() { return 'complete'; }
+      } );
+
+      expect( window.readyFunctions.length ).to.equal( 0 );
+    }
+  );
+} );

--- a/test/unit-test/utilities/on-ready-spec.js
+++ b/test/unit-test/utilities/on-ready-spec.js
@@ -37,31 +37,52 @@ describe( 'on-ready', function() {
 
   it( 'should return early if passed a string',
     function() {
-      onReady( 'foo' );
+      var _readyFuntions = onReady( 'foo' );
 
-      expect( typeof window.readyFuntions ).to.equal( 'undefined' );
-      expect( window.readyFunctions.length ).to.equal( 0 );
+      expect( typeof _readyFuntions ).to.equal( 'undefined' );
     }
   );
 
-  it( 'should add a funtion to the global array but not trigger it' +
+  it( 'should add a funtion to the saved array but not trigger it' +
        'till readyState completes',
     function() {
       var readyReturn;
 
-      onReady( function() {
+      var _readyFunctions = onReady( function() {
         readyReturn = 'foo';
       } );
 
-      expect( typeof window.readyFunctions ).to.equal( 'object' );
-      expect( window.readyFunctions.length ).to.equal( 1 );
+      expect( typeof _readyFunctions ).to.equal( 'object' );
+      expect( _readyFunctions.length ).to.equal( 1 );
+      expect( readyReturn ).to.equal( undefined );
+    }
+  );
+
+  // Due to the issue listed in the next two tests, this returns 3 instead
+  // of two because it's never firing and cleaning the array in the
+  // previous test
+  xit( 'should add a funtion to the saved array each time it is called',
+    function() {
+      var readyReturn;
+      var _readyFunctions;
+
+      _readyFunctions = onReady( function() {
+        readyReturn = 'foo';
+      } );
+
+      _readyFunctions = onReady( function() {
+        readyReturn = 'bar';
+      } );
+
+      expect( typeof _readyFunctions ).to.equal( 'object' );
+      expect( _readyFunctions.length ).to.equal( 2 );
       expect( readyReturn ).to.equal( undefined );
     }
   );
 
   // It seems that even though we're striggering the readyState,
   // it's not triggering the change in our coude
-  xit( 'should trigger the function after readyState completes',
+  xit( 'should trigger the saved functions after readyState completes',
     function() {
       var readyReturn;
 
@@ -80,7 +101,7 @@ describe( 'on-ready', function() {
   // I believe it's the same issue here
   xit( 'should clear the array after readyState completes',
     function() {
-      onReady( function() {
+      var _readyFunctions = onReady( function() {
         return 'foo';
       } );
 
@@ -88,7 +109,7 @@ describe( 'on-ready', function() {
         get: function() { return 'complete'; }
       } );
 
-      expect( window.readyFunctions.length ).to.equal( 0 );
+      expect( _readyFunctions.length ).to.equal( 0 );
     }
   );
 } );

--- a/test/unit-test/utilities/on-ready-spec.js
+++ b/test/unit-test/utilities/on-ready-spec.js
@@ -11,13 +11,13 @@ var _documentState;
 const DOCUMENT_STATES = {
   COMPLETE: 'complete',
   LOADING:  'loading'
-}
+};
 
 function setDocumentState( state ) {
   _documentState = state;
 }
 
-function triggerReadyState( state , time=100) {
+function triggerReadyState( state, time = 100 ) {
 
   return new Promise( function readyStateChange( resolve, reject ) {
     window.setTimeout( function() {
@@ -35,9 +35,9 @@ describe( 'on-ready', function() {
     onReady = require( BASE_JS_PATH + '/utilities/on-ready' ).onReady;
 
     Object.defineProperty( document, 'readyState', {
-         get: function() {
-            return _documentState
-          }
+      get: function() {
+        return _documentState;
+      }
     } );
   } );
 
@@ -63,7 +63,7 @@ describe( 'on-ready', function() {
 
     function() {
       var readyReturn;
-      var _readyFunctions
+      var _readyFunctions;
 
       onReady( function() {
         readyReturn = 'foo';
@@ -76,11 +76,11 @@ describe( 'on-ready', function() {
       expect( _readyFunctions.length ).to.equal( 2 );
 
       return triggerReadyState( DOCUMENT_STATES.COMPLETE )
-             .then( function () {
+              .then( function() {
                 expect( typeof _readyFunctions ).to.equal( 'object' );
                 expect( _readyFunctions.length ).to.equal( 0 );
-             } );
-      }
+              } );
+    }
   );
 
   it( 'should add a function to the saved array but not trigger it' +
@@ -88,7 +88,7 @@ describe( 'on-ready', function() {
 
     function() {
       var readyReturn;
-      var _readyFunctions
+      var _readyFunctions;
 
       onReady( function() {
         readyReturn = 'foo';
@@ -101,11 +101,11 @@ describe( 'on-ready', function() {
       expect( _readyFunctions.length ).to.equal( 2 );
 
       return triggerReadyState( DOCUMENT_STATES.LOADING )
-             .then( function () {
-                expect( typeof _readyFunctions ).to.equal( 'object' );
-                expect( _readyFunctions.length ).to.equal( 2 );
-             } );
-      }
+              .then( function () {
+                 expect( typeof _readyFunctions ).to.equal( 'object' );
+                 expect( _readyFunctions.length ).to.equal( 2 );
+              } );
+    }
   );
 
 } );


### PR DESCRIPTION
There are times we need to wait for the page to complete before triggering scripting. One of these is with the expandables height calculation. This adds support for an onReady utility that will trigger functions after the page is loaded. It does this by collecting them all in a global array set to the window object and triggering them on the page's change to the `readyState` to complete. Once finished, it will reset the global array so they aren't accidentally triggered again.

For testing, I had to create my own `document.readyState` object because the browser's is read only. The only issue is, the onReady code doesn't follow the changes to the custom object. Could use some help figuring out how to make these test run as expected.

NOTE: `mocha-jsdom` is deprecated. Replaced with the suggested `jsdom-global` here to work around `window` issues.